### PR TITLE
fix: Add default_ipv4 to required_facts to gather ansible_hostname fact

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.4.1] - 2024-01-23
+--------------------
+
+### Other Changes
+
+- ci: Add a basic test for ad_integration_preserve_authselect_profile (#81)
+
 [1.4.0] - 2024-01-16
 --------------------
 

--- a/tests/tests_dyndns.yml
+++ b/tests/tests_dyndns.yml
@@ -19,6 +19,7 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: all,!ad
+  gather_facts: false
   vars:
     # if we don't have a real AD server, just verify the config
     # file is written properly

--- a/tests/tests_preserve_authselect.yml
+++ b/tests/tests_preserve_authselect.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that the role ad_integration_preserve_authselect_profile works
+  hosts: all,!ad
+  gather_facts: false  # test that role works in this case
+  vars:
+    # sample realm that will skip joining realm step
+    ad_integration_realm: "{{ __ad_integration_sample_realm }}"
+    ad_integration_password: Secret123
+    ad_integration_preserve_authselect_profile: true
+
+  tasks:
+    - name: Test - Run the system role
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Test - Check that realmd config is present
+      stat:
+        path: /etc/realmd.conf
+      register: __stat_result
+      failed_when: not __stat_result.stat.exists
+      changed_when: false
+
+    - name: Get realmd.conf
+      slurp:
+        path: /etc/realmd.conf
+      register: realmd_conf_raw
+
+    - name: Decode realmd.conf
+      set_fact:
+        realmd_conf: "{{ realmd_conf_raw.content | b64decode }}"
+
+    - name: Test - Check that expected strings are in realmd.conf
+      assert:
+        that:
+          - "'sssd-enable-logins = /usr/bin/sh' in realmd_conf"
+          - "'sssd-disable-logins = /bin/true' in realmd_conf"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ __ad_integration_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
+  - default_ipv4
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module


### PR DESCRIPTION
Enhancement: Add default_ipv4 to required_facts to gather ansible_hostname fact

Reason: The role didn't gather ansible_hostname but used it in tasks/main.yml 

Result: The bug is fixed
