### PR TITLE
test: Replace deprecated community.windows.win_domain_user and group modules

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,6 +44,6 @@ jobs:
           mkdir -p "$coll_dir/.git"
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v6
+        uses: ansible/ansible-lint@v24
         with:
           working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+[1.4.3] - 2024-03-08
+--------------------
+
+### Bug Fixes
+
+- fix: Sets domain name lower case in realmd.conf section header (#88)
+
+### Other Changes
+
+- ci: bump ansible/ansible-lint from 6 to 24 (#86)
+- test: test for lower case realm in realmd.conf (#89)
+
 [1.4.2] - 2024-02-14
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.4.1] - 2024-01-23
+--------------------
+
+### Other Changes
+
+- ci: Add a basic test for ad_integration_preserve_authselect_profile (#81)
+
 [1.4.0] - 2024-01-16
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.4.2] - 2024-02-14
+--------------------
+
+### Bug Fixes
+
+- fix: Add default_ipv4 to required_facts to gather ansible_hostname (#84)
+
+### Other Changes
+
+- ci: fix python unit test - copy pytest config to tests/unit (#83)
+
 [1.4.1] - 2024-01-23
 --------------------
 

--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -5,7 +5,7 @@
 [active-directory]
 default-client = {{ ad_integration_client_software }}
 
-[{{ ad_integration_realm }}]
+[{{ ad_integration_realm | lower }}]
 automatic-id-mapping = {{ ad_integration_auto_id_mapping }}
 {% if ad_integration_computer_ou %}
 computer-ou = {{ ad_integration_computer_ou }}

--- a/tests/tests_basic_join.yml
+++ b/tests/tests_basic_join.yml
@@ -9,6 +9,10 @@
     ad_integration_password: Secret123
 
   tasks:
+    - name: Set test realm
+      set_fact:
+        __ad_integration_sample_realm: MiXeD.cAsE
+
     - name: Test - Run the system role
       include_role:
         name: linux-system-roles.ad_integration
@@ -35,3 +39,9 @@
       vars:
         __file: /etc/realmd.conf
         __fingerprint: "system_role:ad_integration"
+
+    - name: Check that realm name is all lower case
+      command: >-
+        grep -xF "[{{ __ad_integration_sample_realm | lower }}]"
+        /etc/realmd.conf
+      changed_when: false

--- a/tests/tests_dyndns.yml
+++ b/tests/tests_dyndns.yml
@@ -19,6 +19,7 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: all,!ad
+  gather_facts: false
   vars:
     # if we don't have a real AD server, just verify the config
     # file is written properly

--- a/tests/tests_full_integration.yml
+++ b/tests/tests_full_integration.yml
@@ -27,7 +27,7 @@
   hosts: ad
   tasks:
     - name: Create groups
-      win_domain_group:
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -40,7 +40,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"

--- a/tests/tests_full_integration_dc.yml
+++ b/tests/tests_full_integration_dc.yml
@@ -35,7 +35,7 @@
   hosts: ad
   tasks:
     - name: Create groups
-      win_domain_group:
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -48,7 +48,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"

--- a/tests/tests_full_integration_force_rejoin.yml
+++ b/tests/tests_full_integration_force_rejoin.yml
@@ -30,7 +30,7 @@
   hosts: ad
   tasks:
     - name: Create groups
-      win_domain_group:
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -43,7 +43,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"

--- a/tests/tests_preserve_authselect.yml
+++ b/tests/tests_preserve_authselect.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that the role ad_integration_preserve_authselect_profile works
+  hosts: all,!ad
+  gather_facts: false  # test that role works in this case
+  vars:
+    # sample realm that will skip joining realm step
+    ad_integration_realm: "{{ __ad_integration_sample_realm }}"
+    ad_integration_password: Secret123
+    ad_integration_preserve_authselect_profile: true
+
+  tasks:
+    - name: Test - Run the system role
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Test - Check that realmd config is present
+      stat:
+        path: /etc/realmd.conf
+      register: __stat_result
+      failed_when: not __stat_result.stat.exists
+      changed_when: false
+
+    - name: Get realmd.conf
+      slurp:
+        path: /etc/realmd.conf
+      register: realmd_conf_raw
+
+    - name: Decode realmd.conf
+      set_fact:
+        realmd_conf: "{{ realmd_conf_raw.content | b64decode }}"
+
+    - name: Test - Check that expected strings are in realmd.conf
+      assert:
+        that:
+          - "'sssd-enable-logins = /usr/bin/sh' in realmd_conf"
+          - "'sssd-disable-logins = /bin/true' in realmd_conf"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ __ad_integration_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
+  - default_ipv4
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module


### PR DESCRIPTION
Enhancement: Replace deprecated community.windows.win_domain_user and group modules

Reason: `community.windows.win_domain_group` and `community.windows.win_domain_user` has been deprecated

Result: Tests use `microsoft.ad.group` and `microsoft.ad.user` instead